### PR TITLE
[Fixes #15] Initial work on `Katachi::Shape`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,21 @@ AllCops:
     - rubocop-performance
     - rubocop-rake
     - rubocop-rspec
+
+Layout/ClassStructure:
+  Enabled: true
+
+Metrics/BlockLength:
+  AllowedMethods:
+    - describe
+    - context
+
+Style/ClassAndModuleChildren:
+  EnforcedStyle: compact
+
+Style/EndlessMethod:
+  EnforcedStyle: require_single_line
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,10 @@
 AllCops:
   TargetRubyVersion: 3.1
   NewCops: enable
-
+  plugins:
+    - rubocop-performance
+    - rubocop-rake
+    - rubocop-rspec
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,11 @@
+plugins:
+  - rubocop-performance
+  - rubocop-rake
+  - rubocop-rspec
+
 AllCops:
   TargetRubyVersion: 3.1
   NewCops: enable
-  plugins:
-    - rubocop-performance
-    - rubocop-rake
-    - rubocop-rspec
 
 Layout/ClassStructure:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,10 +10,15 @@ AllCops:
 Layout/ClassStructure:
   Enabled: true
 
-Metrics/BlockLength:
-  AllowedMethods:
-    - describe
-    - context
+Metrics/MethodLength:
+  CountAsOne: &count_as_one
+    - array
+    - hash
+    - heredoc
+    - method_call
+
+RSpec/ExampleLength:
+  CountAsOne: *count_as_one
 
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact

--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,5 @@ gem "rubocop", "~> 1.21"
 gem "rubocop-performance", "~> 1.24"
 gem "rubocop-rake", "~> 0.7.1"
 gem "rubocop-rspec", "~> 3.5"
+
+gem "debug", "~> 1.10"

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,6 @@ gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 
 gem "rubocop", "~> 1.21"
+gem "rubocop-performance", "~> 1.24"
+gem "rubocop-rake", "~> 0.7.1"
+gem "rubocop-rspec", "~> 3.5"

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -3,6 +3,7 @@ version: "0.2"
 words:
   - bindir
   - Katachi
+  - kwargs # keyword args
   - pipefail
   - popen
   - readlines

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -3,10 +3,11 @@ version: "0.2"
 words:
   - bindir
   - Katachi
-  - kwargs # keyword args
+  - kwargs
   - pipefail
   - popen
   - readlines
   - rubocop
   - rubygems
+  - shapeables
   - Tannas

--- a/lib/katachi.rb
+++ b/lib/katachi.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
+require_relative "katachi/exceptions"
+require_relative "katachi/shape"
 require_relative "katachi/version"
 
-module Katachi
-  class Error < StandardError; end
-  # Your code goes here...
-end
+# A tool for describing objects in a compact and readable way
+module Katachi; end

--- a/lib/katachi.rb
+++ b/lib/katachi.rb
@@ -2,6 +2,7 @@
 
 require_relative "katachi/exceptions"
 require_relative "katachi/shape"
+require_relative "katachi/shape_tree"
 require_relative "katachi/version"
 
 # A tool for describing objects in a compact and readable way

--- a/lib/katachi/exceptions.rb
+++ b/lib/katachi/exceptions.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Katachi
+  # @abstract Exceptions raised by Katachi inherit from Error
+  class Error < StandardError; end
+
+  # Exception raised when attempting to register a shape with a key that
+  # is already in use
+  class DuplicateShapeKey < Error
+    attr_reader :key
+
+    def initialize(key:, message: "Katachi::Shape already has a shape registered to key '#{key}'")
+      @key = key
+      @message = message
+      super
+    end
+  end
+
+  # Exception raised when attempting to access a shape that either
+  # is not registered or does not exist
+  class MissingShapeKey < Error
+    attr_reader :key
+
+    def initialize(key:, message: "Katachi::Shape has no shape registered to key '#{key}'")
+      @key = key
+      @message = message
+      super
+    end
+  end
+
+  # Exception raised when the `type` of shape is not supported
+  class InvalidShapeType < Error
+    attr_reader :type
+
+    def initialize(
+      type:,
+      message: <<~ERROR
+        Katachi::Shape does not support type '#{type}'
+        Allowed types are:
+        #{Katachi::Shape::TYPE_ATTRIBUTES.keys.map { |t| "- #{t}\n" }}
+      ERROR
+    )
+      @type = type
+      @message = message
+      super
+    end
+  end
+
+  # Exception raised when the additional shape information does not match
+  # what is permitted by for that type
+  class InvalidShapeDefinition < Error; end
+end

--- a/lib/katachi/shape.rb
+++ b/lib/katachi/shape.rb
@@ -3,6 +3,7 @@
 # A consistent interface for defining schemas that are then used
 # as validators.
 class Katachi::Shape
+  RESERVED_KEYS = %i[null undefined boolean].freeze
   TYPE_ATTRIBUTES = {
     array: {},
     boolean: {},
@@ -33,6 +34,7 @@ class Katachi::Shape
   end
 
   def initialize(key:, type:, **input_definition)
+    raise ArgumentError, "#{key} is reserved for Katachi usage" if RESERVED_KEYS.include?(key)
     raise TypeError, "#{self.class.name} expects 'key' to be a symbol" unless key.is_a? Symbol
     raise Katachi::InvalidShapeType.new(type:) unless TYPE_ATTRIBUTES.key?(type)
 
@@ -46,7 +48,7 @@ class Katachi::Shape
       given_value = @input_definition[attr_name]
       next if attr_types.any? { |t| given_value.is_a? t }
 
-      <<~ERROR.gsub("\n", " ")
+      <<~ERROR.tr("\n", " ")
         #{attr_name} cannot be an instance of #{given_value.class.name};
         Allowed classes are [#{attr_types.map(&:name).join(",")}]
       ERROR

--- a/lib/katachi/shape.rb
+++ b/lib/katachi/shape.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+# A consistent interface for defining schemas that are then used
+# as validators.
+class Katachi::Shape
+  TYPE_ATTRIBUTES = {
+    array: {},
+    boolean: {},
+    number: {},
+    object: {},
+    string: {
+      pattern: [NilClass, Regexp],
+      length: [NilClass, Integer, Range]
+    }
+  }.freeze
+
+  attr_reader :description, :key, :input_definition, :type
+
+  @registered_shapes = {}
+
+  def self.register_new(key:, **input_definition)
+    raise Katachi::DuplicateShapeKey.new(key:) if @registered_shapes.key?(key)
+
+    new_shape = new(key:, **input_definition)
+    new_shape.validate_input_definition!
+    @registered_shapes[key] = new_shape
+  end
+
+  def self.[](key)
+    @registered_shapes.fetch(key)
+  rescue KeyError
+    raise Katachi::MissingShapeKey.new(key:)
+  end
+
+  def initialize(key:, type:, **input_definition)
+    raise TypeError, "#{self.class.name} expects 'key' to be a symbol" unless key.is_a? Symbol
+    raise Katachi::InvalidShapeType.new(type:) unless TYPE_ATTRIBUTES.key?(type)
+
+    @key = key
+    @type = type
+    @input_definition = input_definition
+  end
+
+  def validate_input_definition!
+    errors = TYPE_ATTRIBUTES[type].filter_map do |attr_name, attr_types|
+      given_value = @input_definition[attr_name]
+      next if attr_types.any? { |t| given_value.is_a? t }
+
+      <<~ERROR.gsub("\n", " ")
+        #{attr_name} cannot be an instance of #{given_value.class.name};
+        Allowed classes are [#{attr_types.map(&:name).join(",")}]
+      ERROR
+    end
+
+    raise Katachi::InvalidShapeDefinition, errors.join('\n') if errors.any?
+  end
+
+  # TODO: Consider splitting this up into multiple subclasses
+  # eg. StringShape, NumberShape, ObjectShape, etc...
+  def validate_value(value)
+    case type
+    when :string then validate_string(value)
+    else raise NotImplementedErrors # TODO
+    end
+  end
+
+  private
+
+  def validate_string(value) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/MethodLength
+    return ["is not a string"] unless value.is_a? String
+
+    if (pattern = @input_definition[:pattern]) && !pattern.match?(value)
+      errors << "does not match expected pattern of #{pattern}"
+    end
+
+    case (length = @input_definition[:length])
+    when Number
+      errors << "is not the expected length of #{length}" if value.length != length
+    when Range
+      errors << "is outside of expected range of #{length}" unless length.cover?(value)
+    end
+
+    errors
+  end
+end

--- a/lib/katachi/shape_tree.rb
+++ b/lib/katachi/shape_tree.rb
@@ -8,7 +8,6 @@ class Katachi::ShapeTree
     :can_be_boolean,
     :can_be_null,
     :can_be_undefined,
-    :categorized,
     :shapeables
   )
 
@@ -17,7 +16,10 @@ class Katachi::ShapeTree
     @can_be_boolean = !shapeables.delete(:boolean).nil?
     @can_be_null = !shapeables.delete(:null).nil?
     @can_be_undefined = !shapeables.delete(:undefined).nil?
-    @categorized = shapeables.uniq.compact.group_by do |shapeable|
+  end
+
+  def categorized
+    shapeables.uniq.compact.group_by do |shapeable|
       case shapeable
       when Symbol then :shape_keys
       when /^\$\w*:.*$/ then :directives

--- a/lib/katachi/shape_tree.rb
+++ b/lib/katachi/shape_tree.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "debug"
+
+# A data structure for handling composite shapes along with primitive values
+class Katachi::ShapeTree
+  attr_reader(
+    :can_be_boolean,
+    :can_be_null,
+    :can_be_undefined,
+    :categorized,
+    :shapeables
+  )
+
+  def initialize(*shapeables)
+    @shapeables = shapeables
+    @can_be_boolean = !shapeables.delete(:boolean).nil?
+    @can_be_null = !shapeables.delete(:null).nil?
+    @can_be_undefined = !shapeables.delete(:undefined).nil?
+    @categorized = shapeables.uniq.compact.group_by do |shapeable|
+      case shapeable
+      when Symbol then :shape_keys
+      when /^\$\w*:.*$/ then :directives
+      # when Array then TODO
+      # when Object then TODO
+      # when Range then TODO
+      # when RegExp then TODO
+      when String then :strings
+      when Numeric then :numbers
+      end
+    end
+  end
+end

--- a/spec/katachi/shape_spec.rb
+++ b/spec/katachi/shape_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+RSpec.describe Katachi::Shape do
+  before { described_class.instance_variable_set :@registered_shapes, {} }
+
+  let(:valid_init_args) { { key: :foo, type: :string } }
+
+  describe ".register_new" do
+    it "creates a new shape" do
+      expect(described_class.register_new(**valid_init_args)).to be_a Katachi::Shape
+    end
+
+    it "rejects registering a duplicate shape key" do
+      described_class.register_new(**valid_init_args)
+      expect { described_class.register_new(**valid_init_args) }.to raise_error Katachi::DuplicateShapeKey
+    end
+  end
+
+  describe ".[]" do
+    it "allows retrieving shapes from those that are registered" do
+      shape = described_class.register_new(**valid_init_args)
+      expect(described_class[:foo]).to be shape
+    end
+
+    it "throws when trying to access a shape that's not registered" do
+      expect { described_class[:foo] }.to raise_error Katachi::MissingShapeKey
+    end
+  end
+
+  describe "#initialize" do
+    it "succeeds with valid required kwargs for the definition and stores extras into `input_definition`" do
+      instance = described_class.new(**valid_init_args, pattern: /foo/)
+      expect(instance).to have_attributes(
+        **valid_init_args,
+        input_definition: { pattern: /foo/ }
+      )
+    end
+
+    it "rejects non-symbol value for 'key'" do
+      expect { described_class.new(**valid_init_args, key: "foo") }.to raise_error TypeError
+    end
+
+    it "rejects invalid values for 'type'" do
+      expect { described_class.new(**valid_init_args, type: "foo") }.to raise_error Katachi::InvalidShapeType
+    end
+  end
+
+  describe "#validate_shape!" do
+    context "with type: :array" do
+      # TODO
+    end
+
+    context "with type: :boolean" do
+      # TODO
+    end
+
+    context "with type: :number" do
+      # TODO
+    end
+
+    context "with type: :object" do
+      # TODO
+    end
+
+    context "with type: :string" do
+      let(:valid_init_args) { super().merge(type: :string) }
+
+      context "with attribute :pattern" do
+        it "allows for no pattern to be supplied" do
+          shape = described_class.new(**valid_init_args.except(:pattern))
+          expect { shape.validate_input_definition! }.not_to raise_error
+        end
+
+        it "allows for nil to be supplied" do
+          shape = described_class.new(**valid_init_args, pattern: nil)
+          expect { shape.validate_input_definition! }.not_to raise_error
+        end
+
+        it "allows for regex to be supplied" do
+          shape = described_class.new(**valid_init_args, pattern: /foo/)
+          expect { shape.validate_input_definition! }.not_to raise_error
+        end
+
+        it "forbids for strings to be supplied" do
+          shape = described_class.new(**valid_init_args, pattern: "123")
+          expect { shape.validate_input_definition! }.to raise_error Katachi::InvalidShapeDefinition
+        end
+      end
+
+      context "with attribute length" do
+        it "allows for no length to be supplied" do
+          shape = described_class.new(**valid_init_args.except(:length))
+          expect { shape.validate_input_definition! }.not_to raise_error
+        end
+
+        it "allows for nil to be supplied" do
+          shape = described_class.new(**valid_init_args, length: nil)
+          expect { shape.validate_input_definition! }.not_to raise_error
+        end
+
+        it "allows for integers to be supplied" do
+          shape = described_class.new(**valid_init_args, length: 3)
+          expect { shape.validate_input_definition! }.not_to raise_error
+        end
+
+        it "allows for ranges to be supplied" do
+          shape = described_class.new(**valid_init_args, length: 1...4)
+          expect { shape.validate_input_definition! }.not_to raise_error
+        end
+
+        it "forbids for strings to be supplied" do
+          shape = described_class.new(**valid_init_args, length: "3")
+          expect { shape.validate_input_definition! }.to raise_error Katachi::InvalidShapeDefinition
+        end
+      end
+    end
+  end
+end

--- a/spec/katachi/shape_spec.rb
+++ b/spec/katachi/shape_spec.rb
@@ -49,65 +49,55 @@ RSpec.describe Katachi::Shape do
     end
   end
 
-  describe "#validate_shape!" do
-    context "with type: :boolean" do
-      # TODO
-    end
+  describe "#validate_shape!; type: :string" do
+    let(:valid_init_args) { super().merge(type: :string) }
 
-    context "with type: :number" do
-      # TODO
-    end
-
-    context "with type: :string" do
-      let(:valid_init_args) { super().merge(type: :string) }
-
-      context "with attribute :pattern" do
-        it "allows for no pattern to be supplied" do
-          shape = described_class.new(**valid_init_args.except(:pattern))
-          expect { shape.validate_input_definition! }.not_to raise_error
-        end
-
-        it "allows for nil to be supplied" do
-          shape = described_class.new(**valid_init_args, pattern: nil)
-          expect { shape.validate_input_definition! }.not_to raise_error
-        end
-
-        it "allows for regex to be supplied" do
-          shape = described_class.new(**valid_init_args, pattern: /foo/)
-          expect { shape.validate_input_definition! }.not_to raise_error
-        end
-
-        it "forbids for strings to be supplied" do
-          shape = described_class.new(**valid_init_args, pattern: "123")
-          expect { shape.validate_input_definition! }.to raise_error Katachi::InvalidShapeDefinition
-        end
+    context "with attribute :pattern" do
+      it "allows for no pattern to be supplied" do
+        shape = described_class.new(**valid_init_args.except(:pattern))
+        expect { shape.validate_input_definition! }.not_to raise_error
       end
 
-      context "with attribute length" do
-        it "allows for no length to be supplied" do
-          shape = described_class.new(**valid_init_args.except(:length))
-          expect { shape.validate_input_definition! }.not_to raise_error
-        end
+      it "allows for nil to be supplied" do
+        shape = described_class.new(**valid_init_args, pattern: nil)
+        expect { shape.validate_input_definition! }.not_to raise_error
+      end
 
-        it "allows for nil to be supplied" do
-          shape = described_class.new(**valid_init_args, length: nil)
-          expect { shape.validate_input_definition! }.not_to raise_error
-        end
+      it "allows for regex to be supplied" do
+        shape = described_class.new(**valid_init_args, pattern: /foo/)
+        expect { shape.validate_input_definition! }.not_to raise_error
+      end
 
-        it "allows for integers to be supplied" do
-          shape = described_class.new(**valid_init_args, length: 3)
-          expect { shape.validate_input_definition! }.not_to raise_error
-        end
+      it "forbids for strings to be supplied" do
+        shape = described_class.new(**valid_init_args, pattern: "123")
+        expect { shape.validate_input_definition! }.to raise_error Katachi::InvalidShapeDefinition
+      end
+    end
 
-        it "allows for ranges to be supplied" do
-          shape = described_class.new(**valid_init_args, length: 1...4)
-          expect { shape.validate_input_definition! }.not_to raise_error
-        end
+    context "with attribute length" do
+      it "allows for no length to be supplied" do
+        shape = described_class.new(**valid_init_args.except(:length))
+        expect { shape.validate_input_definition! }.not_to raise_error
+      end
 
-        it "forbids for strings to be supplied" do
-          shape = described_class.new(**valid_init_args, length: "3")
-          expect { shape.validate_input_definition! }.to raise_error Katachi::InvalidShapeDefinition
-        end
+      it "allows for nil to be supplied" do
+        shape = described_class.new(**valid_init_args, length: nil)
+        expect { shape.validate_input_definition! }.not_to raise_error
+      end
+
+      it "allows for integers to be supplied" do
+        shape = described_class.new(**valid_init_args, length: 3)
+        expect { shape.validate_input_definition! }.not_to raise_error
+      end
+
+      it "allows for ranges to be supplied" do
+        shape = described_class.new(**valid_init_args, length: 1...4)
+        expect { shape.validate_input_definition! }.not_to raise_error
+      end
+
+      it "forbids for strings to be supplied" do
+        shape = described_class.new(**valid_init_args, length: "3")
+        expect { shape.validate_input_definition! }.to raise_error Katachi::InvalidShapeDefinition
       end
     end
   end

--- a/spec/katachi/shape_spec.rb
+++ b/spec/katachi/shape_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Katachi::Shape do
 
   describe ".register_new" do
     it "creates a new shape" do
-      expect(described_class.register_new(**valid_init_args)).to be_a Katachi::Shape
+      expect(described_class.register_new(**valid_init_args)).to be_a described_class
     end
 
     it "rejects registering a duplicate shape key" do
@@ -40,25 +40,21 @@ RSpec.describe Katachi::Shape do
       expect { described_class.new(**valid_init_args, key: "foo") }.to raise_error TypeError
     end
 
+    it "rejects reserved value for 'key'" do
+      expect { described_class.new(**valid_init_args, key: :null) }.to raise_error ArgumentError
+    end
+
     it "rejects invalid values for 'type'" do
       expect { described_class.new(**valid_init_args, type: "foo") }.to raise_error Katachi::InvalidShapeType
     end
   end
 
   describe "#validate_shape!" do
-    context "with type: :array" do
-      # TODO
-    end
-
     context "with type: :boolean" do
       # TODO
     end
 
     context "with type: :number" do
-      # TODO
-    end
-
-    context "with type: :object" do
       # TODO
     end
 

--- a/spec/katachi/shape_tree_spec.rb
+++ b/spec/katachi/shape_tree_spec.rb
@@ -4,9 +4,17 @@ RSpec.describe Katachi::ShapeTree do
   describe "#initialize" do
     it "categorizes arguments appropriately" do
       tree = described_class.new(:null, :boolean, "foo", "$foo:bar", :foo)
-      expect(tree.can_be_boolean).to be true
-      expect(tree.can_be_null).to be true
-      expect(tree.can_be_undefined).to be false
+      expect(tree).to have_attributes(
+        can_be_boolean: true,
+        can_be_null: true,
+        can_be_undefined: false
+      )
+    end
+  end
+
+  describe "#categorized" do
+    it "categorizes arguments appropriately" do
+      tree = described_class.new(:null, :boolean, "foo", "$foo:bar", :foo)
       expect(tree.categorized).to include(
         strings: ["foo"],
         directives: ["$foo:bar"],

--- a/spec/katachi/shape_tree_spec.rb
+++ b/spec/katachi/shape_tree_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe Katachi::ShapeTree do
+  describe "#initialize" do
+    it "categorizes arguments appropriately" do
+      tree = described_class.new(:null, :boolean, "foo", "$foo:bar", :foo)
+      expect(tree.can_be_boolean).to be true
+      expect(tree.can_be_null).to be true
+      expect(tree.can_be_undefined).to be false
+      expect(tree.categorized).to include(
+        strings: ["foo"],
+        directives: ["$foo:bar"],
+        shape_keys: [:foo]
+      )
+    end
+  end
+end

--- a/spec/katachi_spec.rb
+++ b/spec/katachi_spec.rb
@@ -4,4 +4,16 @@ RSpec.describe Katachi do
   it "has a version number" do
     expect(Katachi::VERSION).not_to be nil
   end
+
+  it "has a shape" do
+    expect(Katachi::Shape).not_to be nil
+  end
+
+  it "has a duplicate shape key error" do
+    expect(Katachi::DuplicateShapeKey).not_to be nil
+  end
+
+  it "has a missing shape key error" do
+    expect(Katachi::MissingShapeKey).not_to be nil
+  end
 end

--- a/spec/katachi_spec.rb
+++ b/spec/katachi_spec.rb
@@ -2,18 +2,18 @@
 
 RSpec.describe Katachi do
   it "has a version number" do
-    expect(Katachi::VERSION).not_to be nil
+    expect(Katachi::VERSION).not_to be_nil
   end
 
   it "has a shape" do
-    expect(Katachi::Shape).not_to be nil
+    expect(Katachi::Shape).not_to be_nil
   end
 
   it "has a duplicate shape key error" do
-    expect(Katachi::DuplicateShapeKey).not_to be nil
+    expect(Katachi::DuplicateShapeKey).not_to be_nil
   end
 
   it "has a missing shape key error" do
-    expect(Katachi::MissingShapeKey).not_to be nil
+    expect(Katachi::MissingShapeKey).not_to be_nil
   end
 end


### PR DESCRIPTION
Note before I forget:
I'll probably want to halt work on the validation aspect and re-approach it using TDD.
`def validate(value, shapes) => errors`
`shapes` can be a string literal, a symbol, a reference, maybe even regex and ranges down the line.
It doesn't make sense to approach validation exclusively from `Katachi::Shape` when it won't cover all cases.

Note:
Break it down. One validation target at a time.
1st null, then strings, then numbers...